### PR TITLE
Plugin adds non-valid gcode commands to file on upload, change to M117 LCD message command

### DIFF
--- a/octoapp/layerutils.py
+++ b/octoapp/layerutils.py
@@ -1,8 +1,8 @@
 
 class LayerUtils:
     
-    LayerChangeCommand = "OCTOAPP_LAYER_CHANGE"
-    DisableLegacyLayerCommand = "OCTOAPP_DISABLE_LAYER_MAGIC"
+    LayerChangeCommand = "M117 OCTOAPP_LAYER_CHANGE"
+    DisableLegacyLayerCommand = "M117 OCTOAPP_DISABLE_LAYER_MAGIC"
 
     @staticmethod
     def CreateLayerChangeCommand(layer):


### PR DESCRIPTION
Since the latest update it seems that the plugin adds several commands to the uploaded GCODE files with the preprocessor hook.

Commands I have found are:
```
OCTOAPP_DISABLE_LAYER_MAGIC
OCTOAPP_LAYER_CHANGE LAYER=<n>
```
These are not valid GCODE commands and it seems they cause other preprocessing plugins to fail. One of them is the PrintTimeGenius plugin which completely screws up its estimates because of these commands. This PR uses the M117 Command with a message that starts with the original command. I.e.:
```
M117 OCTOAPP_DISABLE_LAYER_MAGIC
M117 OCTOAPP_LAYER_CHANGE LAYER=<n>
```
From what I could tell this should not impact the functionality of the plugin.

Lemme know if you agree!

Kind regards,
Aron (Triodes)