### PR TITLE
Update install.sh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -191,7 +191,7 @@ ensure_py_venv()
             # virtualenv path is broken for a few K1 one, for other /opt/bin/virtualenv doesn't exist
             if [[ -f /opt/bin/virtualenv ]]
                 /opt/bin/virtualenv -p /opt/bin/python3 --system-site-packages "${OCTOAPP_ENV}"
-            else 
+            then 
                 virtualenv -p /opt/bin/python3 --system-site-packages "${OCTOAPP_ENV}"
             fi
         else


### PR DESCRIPTION
Fixed Error ./install.sh: line 194: syntax error: unexpected "else" (expecting "then")

I couldn't install or remove the plugin via Helper-Script on my Ender 3v3 KE.

Install Log:
 ┌────────────────────────────────────────────────────────────────┐
 │                       OctoApp Companion                        │
 ├────────────────────────────────────────────────────────────────┤
 │                                                                │
 │ OctoApp Companion allows you to control your printer from    │
 │ OctoApp and get notifications for your prints.               │
 │                                                                │
 └────────────────────────────────────────────────────────────────┘

 Are you sure you want to install OctoApp Companion ? (y/n): y

Info: Downloading OctoApp Companion...
Cloning into '/usr/data/octoapp'...
remote: Enumerating objects: 2784, done.
remote: Counting objects: 100% (348/348), done.
remote: Compressing objects: 100% (183/183), done.
remote: Total 2784 (delta 204), reused 253 (delta 163), pack-reused 2436 (from 1)
Receiving objects: 100% (2784/2784), 19.89 MiB | 1.39 MiB/s, done.
Resolving deltas: 100% (1868/1868), done.
Info: Running OctoApp Companion installer...
./install.sh: line 194: syntax error: unexpected "else" (expecting "then")

Remove Log:
same because remove.sh calls install.sh
